### PR TITLE
Add podcast embed on homepage

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -529,3 +529,14 @@ md-filled-card.profile-card {
     justify-content: center;
   }
 }
+
+/* --- Podcast Embed Section --- */
+.podcast-embed {
+  margin: 2.5rem 0;
+  text-align: center;
+}
+
+.podcast-embed p {
+  margin-bottom: 1rem;
+  color: var(--app-text-color);
+}

--- a/index.html
+++ b/index.html
@@ -155,7 +155,12 @@
                     </md-outlined-button>
                 </a>
             </div>
-            
+
+            <div class="podcast-embed">
+                <p>Stay updated with what I do, research and fun tech topics.</p>
+                <iframe style="border-radius:12px" src="https://open.spotify.com/embed/show/1kfFn7caL2U2wlhaD9IMIa?utm_source=generator" width="100%" height="152" frameBorder="0" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+            </div>
+
             <h2 class="page-section-title">Latest news</h2>
             <div class="news-section">
                 <div class="news-grid" id="newsGrid">


### PR DESCRIPTION
## Summary
- embed podcast iframe above the news section
- style new podcast section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840969af6ac832dbe6051fbfdbf3ad7