### PR TITLE
Lazy load Material components

### DIFF
--- a/assets/js/materialLoader.js
+++ b/assets/js/materialLoader.js
@@ -1,0 +1,20 @@
+const base = 'https://cdn.jsdelivr.net/npm/@material/web@2.3.0';
+const components = [
+  '/button/filled-button.js',
+  '/button/outlined-button.js',
+  '/button/text-button.js',
+  '/icon/icon.js',
+  '/iconbutton/icon-button.js',
+  '/list/list.js',
+  '/list/list-item.js',
+  '/chips/assist-chip.js',
+  '/chips/chip-set.js',
+  '/progress/circular-progress.js',
+  '/divider/divider.js',
+  '/labs/card/elevated-card.js',
+  '/labs/card/filled-card.js',
+  '/labs/card/outlined-card.js'
+];
+Promise.all(components.map(p => import(`${base}${p}?module`)))
+  .catch(err => console.error('Failed to load Material components', err));
+

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
     <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png">
     <link rel="manifest" href="assets/manifest.json">
     <link rel="stylesheet" href="assets/css/tailwind.css">
-    <script type="module" src="https://unpkg.com/@material/web@2.3.0/all.js?module"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" rel="stylesheet">
@@ -21,6 +20,7 @@
     <link rel="stylesheet" href="assets/css/base.css">
     <link rel="stylesheet" href="assets/css/components.css">
     <link rel="stylesheet" href="assets/css/pages.css">
+    <script type="module" src="assets/js/materialLoader.js"></script>
 </head>
 
 <body class="bg-surface-container-lowest">


### PR DESCRIPTION
## Summary
- add script to dynamically import only used Material components
- reference the new loader script instead of the full Material bundle

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ea0278a8832d8447281a8b8d00c2