### PR TITLE
Add music page using Songlink API

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -548,3 +548,76 @@ md-filled-card.profile-card {
   margin-bottom: 1rem;
   color: var(--app-text-color);
 }
+/* --- Songs Page --- */
+#songsPageContainer {
+  padding: 1.5rem;
+  background-color: var(--app-card-bg-color);
+  border-radius: 16px;
+  margin-top: 1rem;
+  color: var(--app-text-color);
+}
+
+.songs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  position: relative;
+}
+
+#songs-status {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--app-secondary-text-color);
+}
+
+#songs-status md-circular-progress {
+  margin-bottom: 1rem;
+}
+
+.song-card {
+  background-color: var(--app-card-bg-color);
+  border: 1px solid var(--app-border-color);
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.song-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  background-color: var(--md-sys-color-surface-variant);
+}
+
+.song-card-content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.song-card-content h3 {
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin: 0 0 0.5rem;
+  color: var(--app-text-color);
+}
+
+.song-card-links {
+  margin-top: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.song-card-links a {
+  text-decoration: none;
+  font-size: 0.9rem;
+  color: var(--md-sys-color-primary);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,6 @@
 // Global DOM element references needed by multiple modules or for initialization
 let pageContentAreaEl, mainContentPageOriginalEl, appBarHeadlineEl,
-    navHomeLinkEl, navPrivacyPolicyLinkEl, topAppBarEl;
+    navHomeLinkEl, navPrivacyPolicyLinkEl, navSongsLinkEl, topAppBarEl;
 
 document.addEventListener('DOMContentLoaded', () => {
     // --- Get DOM Elements ---
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     appBarHeadlineEl = getDynamicElement('appBarHeadline');
     navHomeLinkEl = getDynamicElement('navHomeLink');
     navPrivacyPolicyLinkEl = getDynamicElement('navPrivacyPolicyLink');
+    navSongsLinkEl = getDynamicElement('navSongsLink');
     topAppBarEl = getDynamicElement('topAppBar');
 
 
@@ -36,6 +37,12 @@ document.addEventListener('DOMContentLoaded', () => {
         navPrivacyPolicyLinkEl.addEventListener('click', (e) => {
             e.preventDefault();
             loadPageContent('privacy-policy-website');
+        });
+    }
+    if (navSongsLinkEl) {
+        navSongsLinkEl.addEventListener('click', (e) => {
+            e.preventDefault();
+            loadPageContent('songs');
         });
     }
     // Add listeners for other SPA links here if any

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -53,6 +53,10 @@ async function loadPageContent(pageId, updateHistory = true) {
                 pagePath = 'pages/more/privacy-policy.html';
                 pageTitle = 'Privacy Policy';
                 break;
+            case 'songs':
+                pagePath = 'pages/songs.html';
+                pageTitle = 'My Music';
+                break;
             case 'ads-help-center':
                 pagePath = 'pages/more/apps/ads-help-center.html';
                 pageTitle = 'Ads Help Center';
@@ -95,6 +99,9 @@ async function loadPageContent(pageId, updateHistory = true) {
             }
             const contentHTML = await response.text();
             pageContentArea.innerHTML = contentHTML;
+            if (pageId === 'songs' && typeof loadSongs === 'function' && document.getElementById('songsGrid')) {
+                loadSongs();
+            }
         } catch (error) {
             console.error(`Error loading ${pageTitle}:`, error);
             errorContent = `<div class="page-section active"><p class="error-message text-red-500">Failed to load page: ${pageTitle}. ${error.message}</p></div>`;

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -1,0 +1,50 @@
+const trackIds = [
+    '2jAkanCtUEAJyULRjRI9Iv',
+    '7w6QEs6LkFsI1Z780Pu7EB',
+    '2h4SKinuoj3wVVpyVsG5sS',
+    '3kgXhV03q7fJ6ROSCow42u',
+    '3EAisNhDwQPEYQ9rZa9D6Z'
+];
+
+async function loadSongs() {
+    const grid = document.getElementById('songsGrid');
+    const status = document.getElementById('songs-status');
+    if (!grid) return;
+    if (status) status.style.display = 'flex';
+    grid.innerHTML = '';
+    for (const id of trackIds) {
+        try {
+            const resp = await fetch(`https://api.song.link/v1-alpha.1/links?url=spotify%3Atrack%3A${id}&userCountry=US&songIfSingle=true`);
+            const data = await resp.json();
+            const spotifyKey = `SPOTIFY_SONG::${id}`;
+            const entity = data.entitiesByUniqueId[spotifyKey] || {};
+            const title = entity.title || 'Unknown Title';
+            const img = entity.thumbnailUrl || '';
+            const links = data.linksByPlatform || {};
+            let linksHtml = '';
+            for (const [platform, info] of Object.entries(links)) {
+                const label = platform.charAt(0).toUpperCase() + platform.slice(1);
+                linksHtml += `<a href="${info.url}" target="_blank" rel="noopener noreferrer">${label}</a> `;
+            }
+            const card = document.createElement('div');
+            card.className = 'song-card';
+            card.innerHTML = `
+                <img src="${img}" alt="${title}" loading="lazy">
+                <div class="song-card-content">
+                    <h3>${title}</h3>
+                    <div class="song-card-links">${linksHtml}</div>
+                </div>`;
+            grid.appendChild(card);
+        } catch (err) {
+            console.error('Failed to load song', id, err);
+        }
+    }
+    if (status) status.style.display = 'none';
+}
+
+// When router loads the page dynamically
+document.addEventListener('DOMContentLoaded', () => {
+    if (document.getElementById('songsGrid')) {
+        loadSongs();
+    }
+});

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                     <md-icon slot="start"><span class="material-symbols-outlined">article</span></md-icon>
                     <div slot="headline">Blogs</div>
                 </md-list-item>
-                <md-list-item href="https://linktr.ee/D4rKRekords" target="_blank" rel="noopener noreferrer">
+                <md-list-item href="#songs" id="navSongsLink">
                     <md-icon slot="start"><span class="material-symbols-outlined">music_note</span></md-icon>
                     <div slot="headline">Music</div>
                 </md-list-item>
@@ -231,6 +231,7 @@
     <script src="assets/js/theme.js" defer></script>
     <script src="assets/js/navigationDrawer.js" defer></script>
     <script src="assets/js/bloggerApi.js" defer></script>
+    <script src="assets/js/songs.js" defer></script>
     <script src="assets/js/router.js" defer></script>
     <script src="assets/js/app.js" defer></script>
 

--- a/pages/songs.html
+++ b/pages/songs.html
@@ -1,0 +1,9 @@
+<div id="songsPageContainer" class="page-section active">
+    <h1>My Music</h1>
+    <div class="songs-grid" id="songsGrid">
+        <div id="songs-status">
+            <md-circular-progress indeterminate></md-circular-progress>
+            <span>Loading songs...</span>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add new Music page
- fetch songs from Songlink API
- update navigation and router for new page
- style song cards with new CSS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684676b0e858832daeeaf7c8c4038867