### PR TITLE
Add dynamic MusicBrainz songs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ You can also use any other static server such as `npx serve`.
 
 The songs page fetches track information from the [MusicBrainz](https://musicbrainz.org/doc/MusicBrainz_API) service.
 This API is free for non-commercial use and does not require authentication.
+All songs credited to **D4rK Rekords** are loaded dynamically using the artist's MusicBrainz ID.
 
 ## License
 

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -1,34 +1,28 @@
-const tracks = [
-    { title: 'Thriller', artist: 'Michael Jackson' },
-    { title: 'Billie Jean', artist: 'Michael Jackson' },
-    { title: 'Beat It', artist: 'Michael Jackson' },
-    { title: 'Smooth Criminal', artist: 'Michael Jackson' },
-    { title: 'Bad', artist: 'Michael Jackson' }
-];
 
-async function fetchTrackInfo({ title, artist }) {
-    const url =
-        `https://musicbrainz.org/ws/2/recording/?query=recording:%22${encodeURIComponent(title)}%22%20AND%20artist:%22${encodeURIComponent(artist)}%22&fmt=json&limit=1&inc=releases`;
+const artistMbid = '1217497d-8afd-4c78-9071-9905631d5db4';
+
+async function fetchArtistTracks(mbid) {
+    const url = `https://musicbrainz.org/ws/2/recording?artist=${mbid}&fmt=json&limit=100&inc=releases`;
     const resp = await fetch(url);
     if (!resp.ok) {
         throw new Error(`HTTP ${resp.status}`);
     }
     const data = await resp.json();
-    const rec = data.recordings && data.recordings[0];
-    if (!rec) throw new Error('No recording found');
-    const artists = (rec['artist-credit'] || []).map(a => a.name).join(', ');
-    let image = '';
-    const release = rec.releases && rec.releases[0];
-    if (release && release['release-group'] && release['release-group'].id) {
-        const rgid = release['release-group'].id;
-        image = `https://coverartarchive.org/release-group/${rgid}/front-250`;
-    }
-    return {
-        title: rec.title,
-        artists,
-        image,
-        link: `https://musicbrainz.org/recording/${rec.id}`
-    };
+    return (data.recordings || []).map(rec => {
+        const artists = (rec['artist-credit'] || []).map(a => a.name).join(', ');
+        let image = '';
+        const release = rec.releases && rec.releases[0];
+        if (release && release['release-group'] && release['release-group'].id) {
+            const rgid = release['release-group'].id;
+            image = `https://coverartarchive.org/release-group/${rgid}/front-250`;
+        }
+        return {
+            title: rec.title,
+            artists,
+            image,
+            link: `https://musicbrainz.org/recording/${rec.id}`
+        };
+    });
 }
 
 async function loadSongs() {
@@ -37,27 +31,28 @@ async function loadSongs() {
     if (!grid) return;
     if (status) status.style.display = 'flex';
     grid.innerHTML = '';
-    for (const q of tracks) {
-        try {
-            const track = await fetchTrackInfo(q);
-            const img = track.image || 'https://via.placeholder.com/250?text=No+Art';
-            const title = track.title;
-            const artists = track.artists;
-            const link = track.link;
+    let tracks = [];
+    try {
+        tracks = await fetchArtistTracks(artistMbid);
+    } catch (err) {
+        console.error('Failed to fetch songs list', err);
+    }
+    for (const track of tracks) {
+        const img = track.image || 'https://via.placeholder.com/250?text=No+Art';
+        const title = track.title;
+        const artists = track.artists;
+        const link = track.link;
 
-            const card = document.createElement('div');
-            card.className = 'song-card';
-            card.innerHTML = `
-                <img src="${img}" alt="${title}" loading="lazy">
-                <div class="song-card-content">
-                    <h3>${title}</h3>
-                    <p>${artists}</p>
-                    <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">MusicBrainz</a></div>
-                </div>`;
-            grid.appendChild(card);
-        } catch (err) {
-            console.error('Failed to load song', q.title, err);
-        }
+        const card = document.createElement('div');
+        card.className = 'song-card';
+        card.innerHTML = `
+            <img src="${img}" alt="${title}" loading="lazy">
+            <div class="song-card-content">
+                <h3>${title}</h3>
+                <p>${artists}</p>
+                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">MusicBrainz</a></div>
+            </div>`;
+        grid.appendChild(card);
     }
     if (status) status.style.display = 'none';
 }


### PR DESCRIPTION
## Summary
- fetch songs from MusicBrainz using D4rK Rekords artist ID
- show those songs on the music page
- document the new automatic song loading

## Testing
- `npm install`
- `npx tailwindcss -i ./assets/css/tailwind.input.css -o ./assets/css/tailwind.css --minify`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68468edce064832d93bad513926b6641