### PR TITLE
Fix music feed by using accessible Piped instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ You can also use any other static server such as `npx serve`.
 The songs page fetches track information from the D4rK Rekords YouTube channel
 using the public [Piped API](https://github.com/TeamPiped/Piped). This service
 does not require any authentication. The site requests
-`https://piped.video/api/v1/channels/<channelId>/videos` and renders all
-uploaded tracks automatically.
+`https://pipedapi.ducks.party/channel/<channelId>` and renders the uploaded
+tracks from the `relatedStreams` array.
 
 ## License
 

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -1,18 +1,19 @@
 
-const youtubeChannelId = 'UC80JI44n7GpRGrlR71PtvPg';
+const youtubeChannelId = 'UCtzlWsxUK8FSvLwLDbESw4A';
 async function fetchChannelVideos(channelId) {
-    const url = `https://piped.video/api/v1/channels/${channelId}/videos`;
+    const url = `https://pipedapi.ducks.party/channel/${channelId}`;
     const resp = await fetch(url);
     if (!resp.ok) {
         const errorText = await resp.text();
         throw new Error(`HTTP error! status: ${resp.status}, message: ${errorText}`);
     }
     const data = await resp.json();
-    return (data || []).map(v => ({
+    const streams = data.relatedStreams || [];
+    return streams.map(v => ({
         title: v.title,
-        artists: v.uploader,
+        artists: v.uploaderName,
         image: v.thumbnail,
-        link: `https://www.youtube.com/watch?v=${v.id}`
+        link: `https://www.youtube.com${v.url}`
     }));
 }
 


### PR DESCRIPTION
## Summary
- update songs.js to fetch videos from the `pipedapi.ducks.party` instance
- switch to correct channel ID
- document the new API endpoint in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68470a089830832d9d9afc3cb9f2c974