### PR TITLE
Add underline and blue color to Digi România link

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -103,6 +103,10 @@ p.profile-about {
   color: var(--app-text-color);
   margin-bottom: 1rem;
 }
+.profile-about a {
+  color: var(--app-link-color);
+  text-decoration: underline;
+}
 
 /* --- Chips --- */
 md-chip-set {

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -52,6 +52,7 @@
   --app-nested-list-bg: rgba(0, 0, 0, 0.02);
   --app-theme-button-selected-bg: rgba(61, 220, 132, 0.15);
   --app-footer-text-color: #5f6368;
+  --app-link-color: #4285F4;
   --app-dialog-bg-color: var(--md-sys-color-surface-container-low);
  --md-sys-typescale-label-large-font-family-name: 'Poppins';
   --md-sys-typescale-label-large-font: 'Poppins';
@@ -154,5 +155,6 @@ html.dark {
   --app-nested-list-bg: rgba(255, 255, 255, 0.03);
   --app-theme-button-selected-bg: rgba(150, 222, 161, 0.2);
   --app-footer-text-color: #a0a0a0;
+  --app-link-color: #8ab4f8;
   --app-dialog-bg-color: var(--md-sys-color-surface-container);
 }


### PR DESCRIPTION
## Summary
- create a link color variable for light and dark themes
- underline the Digi România hyperlink and set it to Google Blue

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68485beeaf7c832d829714d6ceeb5a16