### PR TITLE
Add open source acknowledgments to legal notice page

### DIFF
--- a/pages/more/apps/legal-notices.html
+++ b/pages/more/apps/legal-notices.html
@@ -17,6 +17,56 @@
         <p>Kotlin is a statically typed programming language developed by JetBrains. It is designed to interoperate fully with Java, and the JVM version of Kotlin's standard library depends on the Java Class Library.</p>
     </div>
 
+    <h2 id="open-source-licenses">Open Source Licenses</h2>
+
+    <div class="notice-item">
+        <h3 id="independent-jpeg-group">Independent JPEG Group</h3>
+        <p>This software uses code based in part on the work of the Independent JPEG Group.</p>
+    </div>
+
+    <div class="notice-item">
+        <h3 id="libpng-zlib">libpng and zlib</h3>
+        <p>This software is based in part on the libpng library and the zlib data compression library.</p>
+        <p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
+        <ul>
+            <li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+            <li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
+            <li>Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.</li>
+        </ul>
+        <p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+    </div>
+
+    <div class="notice-item">
+        <h3 id="tinyline">TinyLine</h3>
+        <p>This product includes TinyLine software developed by Andrew Girow (<a href="http://www.tinyline.com/">http://www.tinyline.com/</a>).</p>
+    </div>
+
+    <div class="notice-item">
+        <h3 id="speex">Speex</h3>
+        <p>This software is based in part on Speex: Copyright (©) 2002-2003 Jean-Marc Valin.</p>
+    </div>
+
+    <div class="notice-item">
+        <h3 id="flac">FLAC</h3>
+        <p>This software is based in part on FLAC: Copyright (©) 2000-2009 Josh Coalson.</p>
+    </div>
+
+    <div class="notice-item">
+        <h3 id="json-net">Json.NET</h3>
+        <p>Copyright (©) 2007 James Newton-King</p>
+        <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+        <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+        <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+    </div>
+
+    <div class="notice-item">
+        <h3 id="mvvm-light-toolkit">MVVM Light Toolkit</h3>
+        <p>Copyright (c) 2009 - 2010 Laurent Bugnion</p>
+        <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+        <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+        <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+    </div>
+
     <md-divider></md-divider>
 
     <h2 id="additional-acknowledgments">Additional Acknowledgments</h2>
@@ -38,5 +88,5 @@
         <a href="mailto:d4rk7355608@gmail.com">d4rk7355608@gmail.com</a>
     </p>
 
-    <p class="last-updated">This Legal Notice was last updated on May 30, 2025. We may update the Legal Notice from time to time, so please review it frequently.</p>
+    <p class="last-updated">This Legal Notice was last updated on June 14, 2025. We may update the Legal Notice from time to time, so please review it frequently.</p>
 </div>


### PR DESCRIPTION
## Summary
- enhance the legal notices page with open source license sections
- update last updated date to June 14, 2025

## Testing
- `npx tailwindcss -i ./assets/css/tailwind.input.css -o ./assets/css/tailwind.css --minify`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d74d50058832d90bfbd9a16612339