### PR TITLE
Enhance songs page with Songlink data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,14 @@ You can also use any other static server such as `npx serve`.
 ### YouTube Channel Feed
 
 The songs page fetches track information from the D4rK Rekords YouTube channel
-using the public [Piped API](https://github.com/TeamPiped/Piped). This service
-does not require any authentication. The site requests
-`https://pipedapi.ducks.party/channel/<channelId>` and renders the uploaded
-tracks from the `relatedStreams` array.
+using the public [Piped API](https://github.com/TeamPiped/Piped). For each
+video it then queries the [Songlink API](https://song.link/api) to retrieve the
+official cover art and streaming links on other platforms such as Spotify or
+Apple Music. The Piped request does not require authentication while the
+Songlink API is accessed anonymously at
+`https://api.song.link/v1-alpha.1/links?url=<videoUrl>&songIfSingle=true`.
+The returned data is used to populate the song cards with the cover image and
+links to all available services.
 
 ## License
 

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -17,6 +17,39 @@ async function fetchChannelVideos(channelId) {
     }));
 }
 
+async function fetchSongInfo(youtubeUrl) {
+    const apiUrl = `https://api.song.link/v1-alpha.1/links?url=${encodeURIComponent(youtubeUrl)}&songIfSingle=true`;
+    const resp = await fetch(apiUrl);
+    if (!resp.ok) {
+        const errorText = await resp.text();
+        throw new Error(`HTTP error! status: ${resp.status}, message: ${errorText}`);
+    }
+    return await resp.json();
+}
+
+const platformNames = {
+    appleMusic: 'Apple Music',
+    itunes: 'iTunes',
+    spotify: 'Spotify',
+    youtube: 'YouTube',
+    youtubeMusic: 'YouTube Music',
+    google: 'Google Play Music',
+    googleStore: 'Google Store',
+    pandora: 'Pandora',
+    deezer: 'Deezer',
+    tidal: 'Tidal',
+    amazonStore: 'Amazon',
+    amazonMusic: 'Amazon Music',
+    soundcloud: 'SoundCloud',
+    napster: 'Napster',
+    yandex: 'Yandex Music',
+    spinrilla: 'Spinrilla',
+    audius: 'Audius',
+    audiomack: 'Audiomack',
+    anghami: 'Anghami',
+    boomplay: 'Boomplay'
+};
+
 async function loadSongs() {
     const grid = document.getElementById('songsGrid');
     const status = document.getElementById('songs-status');
@@ -30,10 +63,28 @@ async function loadSongs() {
         console.error('Failed to fetch songs list', err);
     }
     for (const track of tracks) {
-        const img = track.image || 'https://via.placeholder.com/250?text=No+Art';
-        const title = track.title;
-        const artists = track.artists;
-        const link = track.link;
+        let songInfo = null;
+        try {
+            songInfo = await fetchSongInfo(track.link);
+        } catch (err) {
+            console.error('Failed to fetch song info', err);
+        }
+
+        const entity = songInfo?.entitiesByUniqueId?.[songInfo?.entityUniqueId];
+        const img = entity?.thumbnailUrl || track.image || 'https://via.placeholder.com/250?text=No+Art';
+        const title = entity?.title || track.title;
+        const artists = entity?.artistName || track.artists;
+        const linksByPlatform = songInfo?.linksByPlatform || {};
+
+        let linksHtml = '';
+        if (Object.keys(linksByPlatform).length > 0) {
+            for (const [platform, data] of Object.entries(linksByPlatform)) {
+                const name = platformNames[platform] || platform;
+                linksHtml += `<a href="${data.url}" target="_blank" rel="noopener noreferrer">${name}</a>`;
+            }
+        } else {
+            linksHtml = `<a href="${track.link}" target="_blank" rel="noopener noreferrer">YouTube</a>`;
+        }
 
         const card = document.createElement('div');
         card.className = 'song-card';
@@ -42,7 +93,7 @@ async function loadSongs() {
             <div class="song-card-content">
                 <h3>${title}</h3>
                 <p>${artists}</p>
-                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">YouTube</a></div>
+                <div class="song-card-links">${linksHtml}</div>
             </div>`;
         grid.appendChild(card);
     }


### PR DESCRIPTION
## Summary
- use Songlink API on the songs page to fetch cover art and links for other music platforms
- document new Songlink API usage in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684fa2906858832d9ae16e4b566da94b