### PR TITLE
Revert to simple Piped API song fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,10 @@ You can also use any other static server such as `npx serve`.
 ### YouTube Channel Feed
 
 The songs page fetches track information from the D4rK Rekords YouTube channel
-using the public [Piped API](https://github.com/TeamPiped/Piped). For each
-video it then queries the [Songlink API](https://song.link/api) to retrieve the
-official cover art and streaming links on other platforms such as Spotify or
-Apple Music. The Piped request does not require authentication while the
-Songlink API is accessed anonymously at
-`https://api.song.link/v1-alpha.1/links?url=<videoUrl>&songIfSingle=true`.
-The returned data is used to populate the song cards with the cover image and
-icons linking to all available services.
+using the public [Piped API](https://github.com/TeamPiped/Piped). This service
+does not require any authentication. The site requests
+`https://pipedapi.ducks.party/channel/<channelId>` and renders the uploaded
+tracks from the `relatedStreams` array.
 
 ## License
 

--- a/assets/js/songs.js
+++ b/assets/js/songs.js
@@ -17,62 +17,6 @@ async function fetchChannelVideos(channelId) {
     }));
 }
 
-async function fetchSongInfo(youtubeUrl) {
-    const apiUrl = `https://api.song.link/v1-alpha.1/links?url=${encodeURIComponent(youtubeUrl)}&songIfSingle=true`;
-    const resp = await fetch(apiUrl);
-    if (!resp.ok) {
-        const errorText = await resp.text();
-        throw new Error(`HTTP error! status: ${resp.status}, message: ${errorText}`);
-    }
-    return await resp.json();
-}
-
-const platformNames = {
-    appleMusic: 'Apple Music',
-    itunes: 'iTunes',
-    spotify: 'Spotify',
-    youtube: 'YouTube',
-    youtubeMusic: 'YouTube Music',
-    google: 'Google Play Music',
-    googleStore: 'Google Store',
-    pandora: 'Pandora',
-    deezer: 'Deezer',
-    tidal: 'Tidal',
-    amazonStore: 'Amazon',
-    amazonMusic: 'Amazon Music',
-    soundcloud: 'SoundCloud',
-    napster: 'Napster',
-    yandex: 'Yandex Music',
-    spinrilla: 'Spinrilla',
-    audius: 'Audius',
-    audiomack: 'Audiomack',
-    anghami: 'Anghami',
-    boomplay: 'Boomplay'
-};
-
-const platformIcons = {
-    appleMusic: 'fa-apple',
-    itunes: 'fa-itunes',
-    spotify: 'fa-spotify',
-    youtube: 'fa-youtube',
-    youtubeMusic: 'fa-youtube',
-    google: 'fa-google-play',
-    googleStore: 'fa-google-play',
-    pandora: 'fa-music',
-    deezer: 'fa-deezer',
-    tidal: 'fa-music',
-    amazonStore: 'fa-amazon',
-    amazonMusic: 'fa-amazon',
-    soundcloud: 'fa-soundcloud',
-    napster: 'fa-napster',
-    yandex: 'fa-yandex',
-    spinrilla: 'fa-music',
-    audius: 'fa-music',
-    audiomack: 'fa-music',
-    anghami: 'fa-music',
-    boomplay: 'fa-music'
-};
-
 async function loadSongs() {
     const grid = document.getElementById('songsGrid');
     const status = document.getElementById('songs-status');
@@ -86,40 +30,10 @@ async function loadSongs() {
         console.error('Failed to fetch songs list', err);
     }
     for (const track of tracks) {
-        let songInfo = null;
-        try {
-            songInfo = await fetchSongInfo(track.link);
-        } catch (err) {
-            console.error('Failed to fetch song info', err);
-        }
-
-        let entity = songInfo?.entitiesByUniqueId?.[songInfo?.entityUniqueId];
-
-        const preferPlatforms = ['spotify', 'appleMusic', 'deezer', 'tidal', 'amazonMusic'];
-        for (const plat of preferPlatforms) {
-            const id = songInfo?.linksByPlatform?.[plat]?.entityUniqueId;
-            if (id && songInfo?.entitiesByUniqueId?.[id]) {
-                entity = songInfo.entitiesByUniqueId[id];
-                break;
-            }
-        }
-
-        const img = entity?.thumbnailUrl || track.image || 'https://via.placeholder.com/250?text=No+Art';
-        const title = entity?.title || track.title;
-        const artists = entity?.artistName || track.artists;
-        const linksByPlatform = songInfo?.linksByPlatform || {};
-
-        let linksHtml = '';
-        if (Object.keys(linksByPlatform).length > 0) {
-            for (const [platform, data] of Object.entries(linksByPlatform)) {
-                const name = platformNames[platform] || platform;
-                const iconClass = platformIcons[platform] || 'fa-music';
-                const prefix = iconClass === 'fa-music' ? 'fa-solid' : 'fa-brands';
-                linksHtml += `<a href="${data.url}" target="_blank" rel="noopener noreferrer" title="${name}"><i class="${prefix} ${iconClass}"></i></a>`;
-            }
-        } else {
-            linksHtml = `<a href="${track.link}" target="_blank" rel="noopener noreferrer" title="YouTube"><i class="fa-brands fa-youtube"></i></a>`;
-        }
+        const img = track.image || 'https://via.placeholder.com/250?text=No+Art';
+        const title = track.title;
+        const artists = track.artists;
+        const link = track.link;
 
         const card = document.createElement('div');
         card.className = 'song-card';
@@ -128,7 +42,7 @@ async function loadSongs() {
             <div class="song-card-content">
                 <h3>${title}</h3>
                 <p>${artists}</p>
-                <div class="song-card-links">${linksHtml}</div>
+                <div class="song-card-links"><a href="${link}" target="_blank" rel="noopener noreferrer">YouTube</a></div>
             </div>`;
         grid.appendChild(card);
     }


### PR DESCRIPTION
## Summary
- revert song list code to version that only uses the Piped API
- update README to remove Songlink explanation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68603f902e30832da30e03f6e7d2a4ef